### PR TITLE
Updated the url for downloading windows edge artifact

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
             <p><img src="SparkEdge128.png"><br/>
                 <strong>pxscene edge</strong><br/>
                 Installer: <a href="http://96.116.56.119/edge/osx/artifacts/pxscene.dmg">OSX</a> | <a
-                        href="#" onClick="downloadArtifact();">Windows</a>
+                        href="http://96.116.56.119/edge/windows/pxscene-setup.exe">Windows</a>
             </p>
         </div>
     </br></br></br>


### PR DESCRIPTION
The url has been updated so as to download the artifact from build server, instead of artifact.